### PR TITLE
updates readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ targets:
   dev:
 modules:
   mymodule: scripts/mymodule.js
-scripts:
+actions:
   doathing:
     - echo $A_VAR
     - mymodule.func


### PR DESCRIPTION
following the examples in the readme, with the `scripts` tag, i'm getting:

```
$ npx terrascript dev doathing
[ERROR] (command) 'doathing ' errored: Error: spawn doathing ENOENT
[ERROR] (terrascript-cli) spawn doathing ENOENT
[ERROR] (terrascript-cli) Error: spawn doathing ENOENT
    at Process.ChildProcess._handle.onexit (node:internal/child_process:283:19)
    at onErrorNT (node:internal/child_process:476:16)
    at processTicksAndRejections (node:internal/process/task_queues:83:21)
```

`:s/scripts/actions`, seems to fix this. 